### PR TITLE
Versus Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ WIP
 
 TODOs:
 
-- Deploy somewhere cheap
+- Deploy somewhere cheap (preferably locally on a Raspberry-Pi)
 - Deploy to Playstore
 - Leverage FB login (friends, leaderboards)
-- Versus mode (using gRPC bidirectional streams)
+- Versus mode (using gRPC bidirectional streams) (server completed, onto client)
 - UI for friends, leaderboards, versus

--- a/backend/common/pkg/error/generator.go
+++ b/backend/common/pkg/error/generator.go
@@ -4,6 +4,7 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+// Generic error wrapper that satisfies gRPC error codes.
 func NewError(err error, errType codes.Code) error {
 	return &Error{
 		err:       err,
@@ -12,6 +13,7 @@ func NewError(err error, errType codes.Code) error {
 	}
 }
 
+// Error wrapper for scylla queries that satisfies gRPC error codes.
 func NewScError(err error, errType codes.Code, query string, args []interface{}) error {
 	return &Error{
 		err:       err,

--- a/backend/common/pkg/ports/port.go
+++ b/backend/common/pkg/ports/port.go
@@ -1,5 +1,6 @@
 package port
 
 const (
-	USERS = ":8080"
+	USERS  = ":8080"
+	VERSUS = ":8082" // avoid 8081 (metro default port)
 )

--- a/backend/versus/cmd/root.go
+++ b/backend/versus/cmd/root.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// nolint:gochecknoinits
+func init() {
+	log.SetFormatter(&log.JSONFormatter{})
+}
+
+func New() *cobra.Command {
+	app := &cobra.Command{
+		Use:   "users",
+		Short: "users backend service",
+	}
+
+	app.AddCommand(newServerCmd())
+
+	return app
+}

--- a/backend/versus/cmd/server.go
+++ b/backend/versus/cmd/server.go
@@ -64,7 +64,7 @@ func grpcServe() error {
 
 	var svcLogger = kitlog.With(logger, "componenet", "service")
 
-	var svcVersus = api.NewVersusService(svcLogger)
+	var svcVersus = api.NewVersusService(svcLogger, api.NewQueueMap())
 
 	listener, err := net.Listen("tcp", "localhost:8080")
 	if err != nil {

--- a/backend/versus/main.go
+++ b/backend/versus/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/Posrabi/flashy/backend/versus/cmd"
+
+func main() {
+	_ = cmd.New().Execute()
+}

--- a/backend/versus/pkg/api/api.go
+++ b/backend/versus/pkg/api/api.go
@@ -1,0 +1,1 @@
+package api

--- a/backend/versus/pkg/api/api.go
+++ b/backend/versus/pkg/api/api.go
@@ -14,13 +14,13 @@ import (
 
 type versusService struct {
 	proto.UnimplementedVersusAPIServer
-	cs     *ConnectServer
+	cs     *connectServer
 	logger log.Logger
 }
 
-func NewVersusService(logger log.Logger) proto.VersusAPIServer {
+func NewVersusService(logger log.Logger, qm *queueMap) proto.VersusAPIServer {
 	return &versusService{
-		cs:     NewConnectServer(logger),
+		cs:     newConnectServer(logger, qm),
 		logger: logger,
 	}
 }

--- a/backend/versus/pkg/api/api.go
+++ b/backend/versus/pkg/api/api.go
@@ -1,1 +1,72 @@
 package api
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-kit/log"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+
+	gerr "github.com/Posrabi/flashy/backend/common/pkg/error"
+	proto "github.com/Posrabi/flashy/protos/versus/proto"
+)
+
+type versusService struct {
+	proto.UnimplementedVersusAPIServer
+	cs     *ConnectServer
+	logger log.Logger
+}
+
+func NewVersusService(logger log.Logger) proto.VersusAPIServer {
+	return &versusService{
+		cs:     NewConnectServer(logger),
+		logger: logger,
+	}
+}
+
+// Join joins a client to the server by creating a channel for it in queueMap.
+func (vs *versusService) Join(ctx context.Context, req *proto.JoinRequest) (*proto.JoinResponse, error) {
+	if err := vs.cs.Join(ctx, req.GetUserId()); err != nil {
+		return nil, err
+	}
+
+	return &proto.JoinResponse{
+		Success: true,
+	}, nil
+}
+
+// Quit close the channel in queueMap.
+func (vs *versusService) Quit(ctx context.Context, req *proto.QuitRequest) (*proto.QuitResponse, error) {
+	if err := vs.cs.Quit(ctx, req.GetUserId()); err != nil {
+		return nil, err
+	}
+
+	return &proto.QuitResponse{
+		Success: true,
+	}, nil
+}
+
+// Connect connects a client to the server, spawning two goroutines in the mean time.
+func (vs *versusService) Connect(stream proto.VersusAPI_ConnectServer) error {
+	group, _ := errgroup.WithContext(context.Background())
+	group.Go(func() error {
+		return vs.cs.Receive(stream)
+	})
+
+	id := stream.Context().Value("user_id")
+	userID, ok := id.(string)
+	if !ok {
+		return gerr.NewError(errors.New("unable to convert context id to string"), codes.InvalidArgument)
+	}
+
+	group.Go(func() error {
+		return vs.cs.Send(stream, userID)
+	})
+
+	if err := group.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/backend/versus/pkg/api/connect.go
+++ b/backend/versus/pkg/api/connect.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+
+	"github.com/go-kit/log"
+	"google.golang.org/grpc/codes"
+
+	gerr "github.com/Posrabi/flashy/backend/common/pkg/error"
+	proto "github.com/Posrabi/flashy/protos/versus/proto"
+)
+
+const CHAN_BUF_SIZE = 5 // nolint: revive
+
+// A global map that holds all of the channels. This should be initialized on server startup.
+type queueMap struct {
+	channels map[string]chan *proto.ConnectData // each client will get its own channel as a message queue
+	mu       sync.Mutex
+}
+
+// Returns a new queue map.
+func newQueueMap() *queueMap {
+	return &queueMap{
+		channels: map[string]chan *proto.ConnectData{},
+	}
+}
+
+// Adds a new queue to the map, this is thread-safe.
+func (q *queueMap) AddQueue(userID string) error {
+	if !q.mu.TryLock() {
+		return gerr.NewError(errors.New("unable to lock, this could case race conditions"), codes.Internal)
+	}
+	defer q.mu.Unlock()
+
+	queue := make(chan *proto.ConnectData, CHAN_BUF_SIZE)
+	_, ok := q.channels[userID]
+	if ok {
+		return gerr.NewError(errors.New("channels already exist"), codes.Internal)
+	}
+
+	q.channels[userID] = queue
+	return nil
+}
+
+func (q *queueMap) GetQueue(userID string) (chan *proto.ConnectData, error) {
+	if !q.mu.TryLock() {
+		return nil, gerr.NewError(errors.New("unable to lock, this could case race conditions"), codes.Internal)
+	}
+	defer q.mu.Unlock()
+
+	val, ok := q.channels[userID]
+	if !ok {
+		return nil, gerr.NewError(errors.New("channel not found"), codes.Internal)
+	}
+
+	return val, nil
+}
+
+// ConnectServer handles all of queueMap related operations.
+type ConnectServer struct {
+	logger log.Logger
+	qm     *queueMap
+}
+
+// Returns a new ConnectServer.
+func NewConnectServer(logger log.Logger) *ConnectServer {
+	return &ConnectServer{
+		logger: logger,
+		qm:     newQueueMap(),
+	}
+}
+
+// Join adds a new queue to the queueMap.
+func (c *ConnectServer) Join(ctx context.Context, userID string) error {
+	return c.qm.AddQueue(userID)
+}
+
+func (c *ConnectServer) Quit(ctx context.Context, userID string) error {
+	q, err := c.qm.GetQueue(userID)
+	if err != nil {
+		return err
+	}
+	close(q)
+	return nil
+}
+
+// Send takes msgs in the queue and send it to the client.
+func (c *ConnectServer) Send(stream proto.VersusAPI_ConnectServer, userID string) error {
+	channel, err := c.qm.GetQueue(userID)
+	if err != nil {
+		return err
+	}
+
+	for {
+		msg, ok := <-channel
+		if msg == nil && !ok { // channel has been closed and no remaining msgs.
+			return nil
+		}
+
+		if err := stream.Send(msg); err != nil {
+			return gerr.NewError(err, codes.Internal)
+		}
+	}
+}
+
+// Receive gather msgs sent by the client to the server and sent it to the according channel.
+func (c *ConnectServer) Receive(stream proto.VersusAPI_ConnectServer) error {
+	for {
+		msg, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+
+		if err != nil {
+			return gerr.NewError(err, codes.Internal)
+		}
+
+		queue, err := c.qm.GetQueue(msg.GetOpponentId())
+		if err != nil {
+			return err
+		}
+		queue <- msg
+	}
+}

--- a/backend/versus/pkg/api/connect_test.go
+++ b/backend/versus/pkg/api/connect_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var tests = []string{
+	"1", "2",
+}
+var qMap = NewQueueMap()
+
+func Test_AddQueue(t *testing.T) {
+	wg := sync.WaitGroup{}
+	for _, ch := range tests {
+		wg.Add(1) // always add before the goroutine
+		go func(id string) {
+			defer wg.Done()
+
+			require.NoError(t, newConnectServer(nil, qMap).qm.AddQueue(id))
+		}(ch)
+	}
+
+	wg.Wait()
+}
+
+func Test_GetQueue(t *testing.T) {
+	wg := sync.WaitGroup{}
+	for _, ch := range tests {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+
+			channel, err := newConnectServer(nil, qMap).qm.GetQueue(id)
+			require.Nil(t, err)
+			require.NotNil(t, channel)
+		}(ch)
+	}
+
+	wg.Wait()
+}
+
+func Test_Quit(t *testing.T) {
+	wg := sync.WaitGroup{}
+
+	for _, ch := range tests {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			ctx := context.Background()
+			cs := newConnectServer(nil, qMap)
+
+			require.NoError(t, cs.Quit(ctx, id))
+
+			c, err := cs.qm.GetQueue(id)
+			require.Nil(t, err)
+			require.Equal(t, 0, len(c))
+		}(ch)
+	}
+
+	wg.Wait()
+}

--- a/backend/versus/pkg/redis/redis.go
+++ b/backend/versus/pkg/redis/redis.go
@@ -1,1 +1,0 @@
-package redis

--- a/backend/versus/pkg/redis/redis.go
+++ b/backend/versus/pkg/redis/redis.go
@@ -1,0 +1,1 @@
+package redis

--- a/go.mod
+++ b/go.mod
@@ -1,19 +1,18 @@
 module github.com/Posrabi/flashy
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-kit/kit v0.12.0
 	github.com/go-kit/log v0.2.0
 	github.com/gocql/gocql v0.0.0-20220216114134-360b71ee0a29
-	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/golang-jwt/jwt/v4 v4.3.0
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.3
+	github.com/google/uuid v1.3.0
 	github.com/joho/godotenv v1.4.0
-	github.com/scylladb/gocqlx/v2 v2.7.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
-	google.golang.org/genproto v0.0.0-20220118154757-00ab72f36ad5
+	github.com/stretchr/testify v1.7.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/grpc v1.44.0
 	google.golang.org/protobuf v1.27.1
 )
@@ -23,17 +22,15 @@ require (
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/uuid v1.3.0 // indirect
+	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/scylladb/go-reflectx v1.0.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20210917221730-978cfadd31cf // indirect
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect
 	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0 // indirect
+	google.golang.org/genproto v0.0.0-20220118154757-00ab72f36ad5 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -759,6 +759,7 @@ google.golang.org/grpc v1.40.1/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9K
 google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.44.0 h1:weqSxi/TMs1SqFRMHCtBgXRs8k3X39QIDEZ0pRcttUg=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/go.sum
+++ b/go.sum
@@ -128,16 +128,11 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gocql/gocql v0.0.0-20220216114134-360b71ee0a29 h1:q+t3TNiSUH/sxYqsIuK431+KIPqsIJyJFFZxsbp7Nos=
 github.com/gocql/gocql v0.0.0-20220216114134-360b71ee0a29/go.mod h1:3gM2c4D3AnkISwBxGnMMsS8Oy4y2lhbPRsH4xnJrHG8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
-github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
-github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.3.0 h1:kHL1vqdqWNfATmA0FNMdmZNMyZI1U6O31X4rlIPoBog=
 github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -187,6 +182,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -215,8 +211,6 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.3 h1:I8MsauTJQXZ8df8qJvEln0kYNc3bSapuaSsEsnFdEFU=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.3/go.mod h1:lZdb/YAJUSj9OqrCHs2ihjtoO3+xK3G53wTYXFWRGDo=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/consul/api v1.11.0/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=
@@ -330,10 +324,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
-github.com/scylladb/go-reflectx v1.0.1 h1:b917wZM7189pZdlND9PbIJ6NQxfDPfBvUaQ7cjj1iZQ=
-github.com/scylladb/go-reflectx v1.0.1/go.mod h1:rWnOfDIRWBGN0miMLIcoPt/Dhi2doCMZqwMCJ3KupFc=
-github.com/scylladb/gocqlx/v2 v2.7.0 h1:/w1VeJHCEAsg9eTculTvIS9eIe/VmEu0clhlH1CF7lc=
-github.com/scylladb/gocqlx/v2 v2.7.0/go.mod h1:jKhM0/LkEAhEOSwd10TCMQdlC5x8aEzK7cXjQcPyMJ0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -770,8 +760,6 @@ google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ5
 google.golang.org/grpc v1.44.0 h1:weqSxi/TMs1SqFRMHCtBgXRs8k3X39QIDEZ0pRcttUg=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0 h1:TLkBREm4nIsEcexnCjgQd5GQWaHcqMzwQV0TX9pq8S0=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0/go.mod h1:DNq5QpG7LJqD2AamLZ7zvKE0DEpVl2BSEVjFycAAjRY=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -789,6 +777,7 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=

--- a/protos/versus/proto/versus.proto
+++ b/protos/versus/proto/versus.proto
@@ -6,5 +6,37 @@ option go_package = "github.com/Posrabi/flashy/protos/versus";
 option java_package = "com.flashy";
 
 service VersusAPI {
-  
+  rpc Join(JoinRequest) returns (JoinResponse) {}
+  rpc Connect(stream ConnectData) returns (stream ConnectData) {}
+  rpc Quit(QuitRequest) returns (QuitResponse) {}
+}
+
+message JoinRequest {
+  string user_id = 1;
+}
+
+message JoinResponse {
+  bool success = 1;
+}
+
+message ConnectData {
+  string user_id = 1;
+  string opponent_id = 2;
+  PlayState state = 3;
+  int32 current_card = 4;
+  int32 total_cards = 5;
+}
+
+message QuitRequest {
+  string user_id = 1;
+}
+
+message QuitResponse {
+  bool success = 1;
+}
+
+enum PlayState {
+  PLAY_STATE_PLAYING = 0;
+  PLAY_STATE_DONE = 1;
+  PLAY_STATE_READY = 2;
 }

--- a/test.sh
+++ b/test.sh
@@ -29,7 +29,8 @@ echo "Connected successfully"
 
 bash db_migrations.sh & wait $!
 
-cd $cur_dir/backend/users/pkg/scylla && go test -v
+cd $cur_dir/backend/users/pkg/scylla && go test -race -v
+cd $cur_dir/backend/versus/pkg/api && go test -race -v
 
 end=`date +%s`
 


### PR DESCRIPTION
- Server Side:
- A new barebone service with no go-kit (go-kit doesn't support streams)
- Use a map of channels as a pool of messaging queues
- Use gRPC bidirectional streams to communicate to the server, then the server will send msgs to the queues
- A separate goroutines will listen to the queue and send them to the client.
- This will use up lots of memory
- Need more benchmarking to assess the overhead of channels and maps